### PR TITLE
Object style dict  key access and key set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Changes will be described from version 0.8.0
 
+## 0.9.0
+Release date: NONE
+
+## Changes
+
+- New optional JS-like style for setting and accessing dictionary values. All other methods still working
+```ruby
+x = {'myKey': 500}
+# access
+print(x.myKey) # prints 500, only valid names allowed
+print(x['myKey']) # still works, prints 500
+print(x[:myKey]) # also still works, prints 500
+# set
+x.myKey = "I changed value"
+print(x.myKey) # prints I changed value
+```
+
 ## 0.8.0
 Release date: *2021/10/14*
 

--- a/src/Units/interpreterclass.pas
+++ b/src/Units/interpreterclass.pas
@@ -1018,9 +1018,16 @@ begin
   begin
     if AName[1] = '$' then
       ERunTimeError.Create('Can''t redefine constant attribute "'+Aname+'" from "' + ASrc.ClassName + '"', FTrace, ANode.PVarName);
-    if AValue.ClassNameIs('TFunctionInstance') and ASrc.ClassNameIs('TClassInstance') then
-      TFunctionInstance(AValue).PIsInstanceFunction := True;
-    ASrc.PMembers.Add(AName, AValue);
+    if ASrc.ClassNameIs('TDictionaryInstance') then
+    begin
+      TDictionaryInstance(ASrc).PValue.AddMember(AName, AValue);
+    end
+    else
+    begin
+      if AValue.ClassNameIs('TFunctionInstance') and ASrc.ClassNameIs('TClassInstance') then
+        TFunctionInstance(AValue).PIsInstanceFunction := True;
+      ASrc.PMembers.Add(AName, AValue);
+    end;
   end;
 end;
 

--- a/src/Units/interpreterclass.pas
+++ b/src/Units/interpreterclass.pas
@@ -1103,7 +1103,16 @@ begin
   begin
     //try
       if (ASrc.ClassNameIs('TDictionaryInstance')) then
-        Ret := TDictionaryInstance(ASrc).PValue.GetMember(AName)
+      begin
+        Ret := TDictionaryInstance(ASrc).PValue.GetMember(AName);
+        if Ret = nil then
+        begin
+          Ret := TDictionaryInstance(ASrc).PDefault;
+          if (ret = nil) then
+            RaiseException('The referenced key "' + AName +
+          '" does not exist at given Dict/List and this dictionary does not have a default fallback value.', 'RunTime');
+        end
+      end
       else
         Ret := TInstanceOf(ASrc.PMembers.Find(Aname));
       if (Ret <> nil) then
@@ -2085,9 +2094,8 @@ begin
         ERunTimeError.Create('This dictionary does not have a default value',
           FTrace, ANode.PToken)
       else
-        ERunTimeError.Create('The referenced key "' + AIndex.AsString +
-          '" does not exist at given Dict/List and this dictionary does not have a default fallback value.',
-          FTrace, ANode.PToken);
+        RaiseException('The referenced key "' + AIndex.AsString +
+          '" does not exist at given Dict/List and this dictionary does not have a default fallback value.', 'RunTime');
 
     end;
   end;

--- a/src/Units/interpreterclass.pas
+++ b/src/Units/interpreterclass.pas
@@ -1095,7 +1095,10 @@ begin
   else
   begin
     //try
-      Ret := TInstanceOf(ASrc.PMembers.Find(Aname));
+      if (ASrc.ClassNameIs('TDictionaryInstance')) then
+        Ret := TDictionaryInstance(ASrc).PValue.GetMember(AName)
+      else
+        Ret := TInstanceOf(ASrc.PMembers.Find(Aname));
       if (Ret <> nil) then
       begin
         if Ret.ClassNameIs('TIntegerInstance') then


### PR DESCRIPTION
- New optional JS-like style for setting and accessing dictionary values. All other methods still working
```ruby
x = {'myKey': 500}
# access
print(x.myKey) # prints 500, only valid names allowed
print(x['myKey']) # still works, prints 500
print(x[:myKey]) # also still works, prints 500
# set
x.myKey = "I changed value"
print(x.myKey) # prints I changed value
```